### PR TITLE
Installation step for GHC 8.8.3 added in README and stack.yaml modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,18 @@ cd haskell-code-explorer
 
 To build Haskell Code Explorer Stack ([https://docs.haskellstack.org/en/stable/README/](https://docs.haskellstack.org/en/stable/README/)) is needed.
 
-At the moment Haskell Code Explorer supports GHC 8.6.5, 8.6.4, GHC 8.6.3, GHC 8.4.4, GHC 8.4.3, GHC 8.2.2, and 8.0.2.
+At the moment Haskell Code Explorer supports GHC 8.8.3, GHC 8.6.5, 8.6.4, GHC 8.6.3, GHC 8.4.4, GHC 8.4.3, GHC 8.2.2, and 8.0.2.
+
+For GHC 8.8.3:
+
+```bash
+stack install
+```
 
 For GHC 8.6.5:
 
 ```bash
-stack install
+stack --stack-yaml=stack-8.6.5.yaml install
 ```
 
 For GHC 8.6.4:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,12 @@
-resolver: lts-14.1
+resolver: lts-15.4
 packages:
 - '.'
 - 'vendor/cabal-helper-0.8.1.2'
 allow-newer: true
 extra-deps:
-  - cabal-plan-0.4.0.0
+  - haddock-library-1.7.0@sha256:8f230ebb680b559256d9c18ce4942ba5bf220b167804b4ebd5cc9e47cc4973cd
+  - cabal-install-3.0.0.0@sha256:5e3c4376e53c06521cca2c037074423dbb967e228af6174bf842ff38aa82b035
+  - git: https://github.com/haskell/hackage-security
+    commit: 2057cdf2abba852881cd9d055c96f03cd8c829e7
+    subdirs:
+      - hackage-security


### PR DESCRIPTION
- stack.yaml has been copied from stack-8.8.3.yaml (it was copied from stack-8.6.5.yaml before)
- installation step for ghc-8.8.3 has been added
- installation step for ghc-8.6.5 has been changed (uses stack-8.6.5.yaml)